### PR TITLE
aop.xml file added to final Jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,7 @@
                 <includes>
                     <include>banner.txt</include>
                     <include>helpMessage.txt</include>
+                    <include>META-INF/aop.xml</include>
                 </includes>
             </resource>
         </resources>


### PR DESCRIPTION
The aop.xml file under resources/META-INF was added in the final jar. With is, client projects won't need to have a local copy of this file for the aspects to work.